### PR TITLE
feat: Add session time display and clock-out confirmation modal

### DIFF
--- a/client/components/tickets/TicketsPage.html
+++ b/client/components/tickets/TicketsPage.html
@@ -13,6 +13,10 @@
     <div class="mb-4 flex items-center gap-4">
       {{#if isClockedInForTeam selectedTeamId}}
         <button id="clockOutBtn" class="btn btn-outline btn-primary">Clock Out</button>
+        <div class="flex items-center gap-2">
+          <img src="/timeharbor-icon.svg" alt="Timer" class="w-8 h-8" />
+          <span class="font-mono text-2xl font-bold">{{currentSessionTime}}</span>
+        </div>
       {{else}}
         <button id="clockInBtn" class="btn btn-outline btn-primary">Clock In</button>
       {{/if}}
@@ -75,4 +79,19 @@
       <p>Create or join a project to start tracking your activities and time.</p>
     </div>
   {{/if}}
+
+  <!-- Clock Out Confirmation Modal -->
+  <dialog id="clockOutModal" class="modal">
+    <div class="modal-box">
+      <h3 class="font-bold text-lg text-success mb-4">✅ Clock Out Successful!</h3>
+      <div class="text-center">
+        <div class="text-6xl mb-4">⏰</div>
+        <p class="text-lg mb-2">You worked for:</p>
+        <p class="text-4xl font-bold text-primary font-mono" id="totalWorkTime">0:00:00</p>
+      </div>
+      <div class="modal-action">
+        <button class="btn btn-primary" onclick="document.getElementById('clockOutModal').close()">Close</button>
+      </div>
+    </div>
+  </dialog>
 </template>


### PR DESCRIPTION
- Introduced a display for the current session time on the TicketsPage when clocked in.
- Implemented a modal that shows total work time upon successful clock-out, enhancing user feedback and experience.
- Updated the JavaScript logic to calculate and format the total work time before stopping the session.