### PR TITLE
feat: Restrict ticket operations to the current user

### DIFF
--- a/client/components/tickets/TicketsPage.js
+++ b/client/components/tickets/TicketsPage.js
@@ -91,8 +91,8 @@ const sessionManager = {
   // Stop a session
   stopSession: async (teamId) => {
     try {
-      // Find ALL running tickets for this team and stop them
-      const runningTickets = Tickets.find({ teamId, startTimestamp: { $exists: true } }).fetch();
+      // Find ALL running tickets for this team created by current user and stop them
+      const runningTickets = Tickets.find({ teamId, createdBy: Meteor.userId(), startTimestamp: { $exists: true } }).fetch();
       
       // Stop all running tickets
       const stopPromises = runningTickets.map(ticket => 
@@ -134,7 +134,7 @@ Template.tickets.onCreated(function () {
     if (teamId) {
       const activeSession = ClockEvents.findOne({ userId: Meteor.userId(), teamId, endTime: null });
       if (activeSession) {
-        const runningTicket = Tickets.findOne({ teamId, startTimestamp: { $exists: true } });
+        const runningTicket = Tickets.findOne({ teamId, createdBy: Meteor.userId(), startTimestamp: { $exists: true } });
         this.activeTicketId.set(runningTicket ? runningTicket._id : null);
       } else {
         this.activeTicketId.set(null);
@@ -164,7 +164,8 @@ Template.tickets.helpers({
     const activeTicketId = Template.instance().activeTicketId.get();
     const now = currentTime.get();
     
-    return Tickets.find({ teamId }).fetch().map(ticket => {
+    // Only show tickets created by the current user
+    return Tickets.find({ teamId, createdBy: Meteor.userId() }).fetch().map(ticket => {
       const isActive = ticket._id === activeTicketId && ticket.startTimestamp;
       const elapsed = isActive ? Math.max(0, Math.floor((now - ticket.startTimestamp) / 1000)) : 0;
       

--- a/server/methods/tickets.js
+++ b/server/methods/tickets.js
@@ -94,6 +94,14 @@ export const ticketMethods = {
     check(ticketId, String);
     check(now, Number);
     if (!this.userId) throw new Meteor.Error('not-authorized');
+    
+    // Verify user owns the ticket
+    const ticket = Tickets.findOne(ticketId);
+    if (!ticket) throw new Meteor.Error('not-found', 'Ticket not found');
+    if (ticket.createdBy !== this.userId) {
+      throw new Meteor.Error('not-authorized', 'You can only start your own tickets');
+    }
+    
     return Tickets.updateAsync(ticketId, { $set: { startTimestamp: now } });
   },
 
@@ -101,8 +109,16 @@ export const ticketMethods = {
     check(ticketId, String);
     check(now, Number);
     if (!this.userId) throw new Meteor.Error('not-authorized');
+    
     return Tickets.findOneAsync(ticketId).then(ticket => {
-      if (ticket && ticket.startTimestamp) {
+      if (!ticket) throw new Meteor.Error('not-found', 'Ticket not found');
+      
+      // Verify user owns the ticket
+      if (ticket.createdBy !== this.userId) {
+        throw new Meteor.Error('not-authorized', 'You can only stop your own tickets');
+      }
+      
+      if (ticket.startTimestamp) {
         const elapsed = Math.floor((now - ticket.startTimestamp) / 1000);
         const prev = ticket.accumulatedTime || 0;
         return Tickets.updateAsync(ticketId, {
@@ -120,6 +136,11 @@ export const ticketMethods = {
 
     const ticket = await Tickets.findOneAsync(ticketId);
     if (!ticket) throw new Meteor.Error('not-found', 'Ticket not found');
+
+    // Verify user is the creator of the ticket
+    if (ticket.createdBy !== this.userId) {
+      throw new Meteor.Error('not-authorized', 'You can only edit your own tickets');
+    }
 
     // Verify user is a member of the team
     const team = await Teams.findOneAsync({ _id: ticket.teamId, members: this.userId });
@@ -139,6 +160,11 @@ export const ticketMethods = {
 
     const ticket = await Tickets.findOneAsync(ticketId);
     if (!ticket) throw new Meteor.Error('not-found', 'Ticket not found');
+
+    // Verify user is the creator of the ticket
+    if (ticket.createdBy !== this.userId) {
+      throw new Meteor.Error('not-authorized', 'You can only delete your own tickets');
+    }
 
     // Verify user is a member of the team
     const team = await Teams.findOneAsync({ _id: ticket.teamId, members: this.userId });


### PR DESCRIPTION
- Updated ticket methods to ensure users can only start, stop, edit, or delete their own tickets.
- Modified queries in the TicketsPage to only display tickets created by the current user, enhancing user-specific ticket management.