### PR TITLE
fix: Update clock-out display and correct earliest clock-in logic in …

### DIFF
--- a/client/components/home/HomePage.js
+++ b/client/components/home/HomePage.js
@@ -213,8 +213,8 @@ Template.home.onCreated(function () {
               totalSeconds += daySessionSeconds;
               
               if (sessionStart >= dayBoundaries.start && sessionStart <= dayBoundaries.end) {
-                if (!firstClockIn || sessionStart > firstClockIn) {
-                  firstClockIn = sessionStart;
+                if (!firstClockIn || sessionStart < firstClockIn) {
+                  firstClockIn = sessionStart; // earliest clock-in
                 }
               }
              


### PR DESCRIPTION
…HomePage

- Changed the clock-out display message to 'Not clocked-out' for clarity when no value is present.
- Corrected the logic for determining the earliest clock-in time to ensure it captures the earliest session accurately.