### PR TITLE
feat: Update admin access and messaging in layout and admin components

### DIFF
--- a/client/components/admin/admin.html
+++ b/client/components/admin/admin.html
@@ -40,7 +40,7 @@
         </div>
     {{else}}
       <div class="alert alert-warning">
-        <p>Please select a team to review time entries. You can only review teams where you are an admin.</p>
+        <p>Please select a team to review time entries.</p>
       </div>
          {{/if}}
    </div>

--- a/client/components/layout/MainLayout.html
+++ b/client/components/layout/MainLayout.html
@@ -8,7 +8,9 @@
       <a href="/teams" class="btn btn-ghost hover:bg-primary-focus">Teams</a>
       <a href="/tickets" class="btn btn-ghost hover:bg-primary-focus">Tickets</a>
       <a href="/calendar" class="btn btn-ghost hover:bg-primary-focus">Calendar</a>
-      <a href="/admin" class="btn btn-ghost hover:bg-primary-focus">Admin Review</a>
+      {{#if isTeamAdmin}}
+        <a href="/admin" class="btn btn-ghost hover:bg-primary-focus">Admin Review</a>
+      {{/if}}
     </nav>
     <div class="flex-none flex items-center gap-2">
       <button id="themeToggle" class="btn btn-ghost btn-sm btn-square" title="Toggle theme">

--- a/client/components/layout/MainLayout.js
+++ b/client/components/layout/MainLayout.js
@@ -3,7 +3,7 @@ import { ReactiveVar } from 'meteor/reactive-var';
 import { FlowRouter } from 'meteor/ostrio:flow-router-extra';
 import { currentScreen } from '../auth/AuthPage.js';
 import { currentRouteTemplate } from '../../routes.js';
-import { ClockEvents } from '../../../collections.js';
+import { ClockEvents, Teams } from '../../../collections.js';
 import { dateToLocalString } from '../../utils/DateUtils.js';
 
 const MESSAGE_TIMEOUT = 3000;
@@ -126,6 +126,9 @@ if (Template.mainLayout) {
     },
     logoutBtnAttrs() {
       return isLogoutLoading.get() ? { disabled: true } : {};
+    },
+    isTeamAdmin() {
+      return !!Teams.findOne({ admins: Meteor.userId() });
     }
   });
 


### PR DESCRIPTION
- Added conditional rendering for the Admin Review link in the MainLayout to display only for team admins.
- Simplified the warning message in the admin component by removing redundant information about admin permissions.